### PR TITLE
github-actions: Change docker image name

### DIFF
--- a/.github/workflows/docker-image-publish.yaml
+++ b/.github/workflows/docker-image-publish.yaml
@@ -12,7 +12,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ github.repository_owner }}/ddns_update
 
 jobs:
   build:


### PR DESCRIPTION
When git repository name is camel style,
{{github.repository}} is rendered as all lowercase letters. This is a bit ugly, so this patch changes to specifying the image  name directly and avoids that.